### PR TITLE
Multi-cursor highlights

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,6 @@
     },
     "search.exclude": {
         "out": true // set this to false to include "out" folder in search results
-    }
+    },
+    "typescript.tsdk": "node_modules\\typescript\\lib"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "highlight-matching-tag",
-  "version": "0.8.0",
+  "version": "0.8.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1519,9 +1519,9 @@
       }
     },
     "moo": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/moo/-/moo-0.4.3.tgz",
-      "integrity": "sha512-gFD2xGCl8YFgGHsqJ9NKRVdwlioeW3mI1iqfLNYQOv0+6JRwG58Zk9DIGQgyIaffSYaO1xsKnMaYzzNr1KyIAw=="
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.0.tgz",
+      "integrity": "sha512-AMv6iqhTEd5vT/cQlH6cammKS5ekyHhyqTRKi5zKMWl1RTyFnQ3ohPSBNSm8ySe2wlxSKwDonr9D5ZT44mdO3g=="
     },
     "ms": {
       "version": "2.0.0",
@@ -1689,9 +1689,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.14.3.tgz",
-      "integrity": "sha512-qZDVnCrnpsRJJq5nSsiHCE3BYMED2OtsI+cmzIzF1QIfqm5ALf8tEJcO27zV1gKNKRPdhjO0dNWnrzssDQ1tFg==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.15.2.tgz",
+      "integrity": "sha512-YgPLFFA0CdKL4Eg2IHtUSjzj/BWgszDHiNQAe0VAIBse34148whfdzLagRL+QiKS+YfK5ftB6X4v/MBw8yCoug==",
       "dev": true
     },
     "process-nextick-args": {
@@ -2142,9 +2142,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.5.tgz",
-      "integrity": "sha512-muYNWV9j5+3mXoKD6oPONKuGUmYiFX14gfo9lWm9ZXRHOqVDQiB4q1CzFPbF4QLV2E9TZXH6oK55oQ94rn3PpA==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.6.tgz",
+      "integrity": "sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==",
       "dev": true
     },
     "unique-stream": {

--- a/package.json
+++ b/package.json
@@ -531,11 +531,11 @@
     "@types/moo": "^0.4.2",
     "@types/node": "^10.11.5",
     "mocha": "^5.2.0",
-    "prettier": "^1.14.3",
+    "prettier": "^1.15.2",
     "tslint": "^5.11.0",
     "tslint-config-prettier": "^1.15.0",
     "tslint-plugin-prettier": "^2.0.1",
-    "typescript": "^3.1.5",
+    "typescript": "^3.1.6",
     "vscode": "^1.1.21"
   },
   "prettier": {
@@ -544,6 +544,6 @@
     "printWidth": 100
   },
   "dependencies": {
-    "moo": "^0.4.3"
+    "moo": "^0.5.0"
   }
 }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -23,7 +23,7 @@ export async function jumpToMatchingTag() {
     )
 
     const newPosition = openingTagRange.contains(position)
-      ? editor.document.positionAt(match.closing.start).translate(0, 1)
+      ? editor.document.positionAt(match.closing.start + 1)
       : openingTagStartPos.translate(0, 1)
 
     editor.selection = new vscode.Selection(newPosition, newPosition)

--- a/src/tagStyler.ts
+++ b/src/tagStyler.ts
@@ -28,7 +28,6 @@ export default class TagStyler {
   private activeDecorations: vscode.TextEditorDecorationType[] = []
 
   public decoratePair = (pair: hmt.Match, editor: vscode.TextEditor) => {
-    this.clearDecorations()
     this.decorateTag(pair.opening, this.config.opening, editor, true)
 
     if (pair.opening.start !== pair.closing.start) {

--- a/tslint.json
+++ b/tslint.json
@@ -14,6 +14,11 @@
       true,
       "dev"
     ],
-    "object-literal-sort-keys": false
+    "object-literal-sort-keys": false,
+    "quotemark": [
+      true,
+      "single",
+      "avoid-template"
+    ]
   }
 }


### PR DESCRIPTION
- Added support for multi-cursor highlights
- Updated dependencies
- Removed/replace unnecessary template strings

I moved the `editor` reference back to being local and initialized the other non-local variables to avoid having to handle when they're undefined.