### PR TITLE
Ignore tags in commented code

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -87,15 +87,6 @@ export function activate(context: vscode.ExtensionContext) {
 
       if (editorText !== editor.document.getText()) {
         editorText = editor.document.getText()
-        
-        let match;
-        let regEx = /<!--([\s\S])*?-->/gm; //matches comments - lazy match
-        while (match = regEx.exec(editorText)) {
-            let len = match[0].length
-            let repl = " ".repeat(len);
-            editorText = editorText.substring(0, match.index) + repl + editorText.substring(match.index + len); //replace comment with spaces
-        }
-        
         tagsList = parseTags(editorText, config.emptyElements)
       }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -87,6 +87,16 @@ export function activate(context: vscode.ExtensionContext) {
 
       if (editorText !== editor.document.getText()) {
         editorText = editor.document.getText()
+        
+        // Preprocess text for comments (replace comments with string of spaces)
+        let match;
+        let regEx = /<!--((?!<!--)[\s\S])*-->/gm; //matches comments
+        while (match = regEx.exec(editorText)) {
+            let len = match[0].length
+            let repl = " ".repeat(len);
+            editorText = editorText.substring(0, match.index) + repl + editorText.substring(match.index + len); //replace comment with spaces
+        }
+        
         tagsList = parseTags(editorText, config.emptyElements)
       }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -88,9 +88,8 @@ export function activate(context: vscode.ExtensionContext) {
       if (editorText !== editor.document.getText()) {
         editorText = editor.document.getText()
         
-        // Preprocess text for comments (replace comments with string of spaces)
         let match;
-        let regEx = /<!--((?!<!--)[\s\S])*-->/gm; //matches comments
+        let regEx = /<!--([\s\S])*?-->/gm; //matches comments - lazy match
         while (match = regEx.exec(editorText)) {
             let len = match[0].length
             let repl = " ".repeat(len);

--- a/src/tagLexer.ts
+++ b/src/tagLexer.ts
@@ -25,7 +25,7 @@ const blockState = (closingChar: string): moo.Rules => {
 export default moo.states({
   main: {
     // Try to match comment
-    commentOpening: {match: /[\s]*?<!--/, push: 'inComment' },
+    commentOpening: {match: /(?:[\s]*?)(?:<!--|{\/\*)/, push: 'inComment' },
 
     // Try to match anything that looks like a tag
     tagOpening: { match: /<(?!\/)(?=>|\w)[\w-.:]*(?=[^]*>)(?=\s|\/?>)/, push: 'inTag' },
@@ -39,7 +39,7 @@ export default moo.states({
     ignoreTheRest: { match: /[^]+/, lineBreaks: true }
   },
   inComment: {
-    closeComment: { match: /[^]*?-->/, pop: 1}
+    closeComment: { match: /(?:[^]*?)(?:-->|\*\/})/, pop: 1}
   },
   inTag: {
     // Closes tag and returns to main state

--- a/src/tagLexer.ts
+++ b/src/tagLexer.ts
@@ -24,6 +24,9 @@ const blockState = (closingChar: string): moo.Rules => {
 
 export default moo.states({
   main: {
+    // Try to match comment
+    commentOpening: {match: /[\s]*?<!--/, push: 'inComment' },
+
     // Try to match anything that looks like a tag
     tagOpening: { match: /<(?!\/)(?=>|\w)[\w-.:]*(?=[^]*>)(?=\s|\/?>)/, push: 'inTag' },
 
@@ -34,6 +37,9 @@ export default moo.states({
     ignore: { match: /(?:[^])+?(?=<(?:(?=\/|\w|>)\S*))/, lineBreaks: true },
 
     ignoreTheRest: { match: /[^]+/, lineBreaks: true }
+  },
+  inComment: {
+    closeComment: { match: /[^]*?-->/, pop: 1}
   },
   inTag: {
     // Closes tag and returns to main state

--- a/test/tagParser.test.ts
+++ b/test/tagParser.test.ts
@@ -648,7 +648,7 @@ suite('TagParser Tests', () => {
       assert.deepEqual(parseTags(data, defaultEmptyElements), expected)
     })
 
-    test('ignore tags in comments', () => {
+    test('ignore tags in html comments', () => {
       const data = `
         <div class="tag">
           <!-- </div> some text <div> -->
@@ -659,6 +659,28 @@ suite('TagParser Tests', () => {
           attributeNestingLevel: 0,
           opening: { name: 'div', start: 0, end: 17 },
           closing: { name: 'div', start: 68, end: 74 }
+        }
+      ]
+      assert.deepEqual(parseTags(data, defaultEmptyElements), expected)
+    })
+
+    test('ignore tags in JSX comments', () => {
+      const data = `
+        <div className="dropdown">
+          {/* text </div> more text */}
+          <Button whenClicked={this.onClick} ></Button>
+        </div>
+      `.trim()
+      const expected: hmt.PartialMatch[] = [
+        {
+          attributeNestingLevel: 0,
+          opening: { name: 'div', start: 0, end: 26 },
+          closing: { name: 'div', start: 131, end: 137 }
+        },
+        {
+          attributeNestingLevel: 0,
+          opening: { name: 'Button', start: 77, end: 113 },
+          closing: { name: 'Button', start: 113, end: 122 }
         }
       ]
       assert.deepEqual(parseTags(data, defaultEmptyElements), expected)

--- a/test/tagParser.test.ts
+++ b/test/tagParser.test.ts
@@ -647,5 +647,21 @@ suite('TagParser Tests', () => {
       const expected: hmt.PartialMatch[] = []
       assert.deepEqual(parseTags(data, defaultEmptyElements), expected)
     })
+
+    test('ignore tags in comments', () => {
+      const data = `
+        <div class="tag">
+          <!-- </div> some text <div> -->
+        </div>
+      `.trim()
+      const expected: hmt.PartialMatch[] = [
+        {
+          attributeNestingLevel: 0,
+          opening: { name: 'div', start: 0, end: 17 },
+          closing: { name: 'div', start: 68, end: 74 }
+        }
+      ]
+      assert.deepEqual(parseTags(data, defaultEmptyElements), expected)
+    })
   })
 })


### PR DESCRIPTION
The patch replaces comments in received copy of editor text with equal length string of spaces, thus avoids comments being considered as part of code. Fixes #97
Edit: this was a naive fix. Approach changed later.