### PR TITLE
Remove unwanted affiliate toast

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -37,7 +37,7 @@ function updateTagStatusBarItem(
   }
 }
 
-function promptInfoMessage(oldVersion: string | undefined) {
+function promptSettingsMigration() {
   if (config.hasOldSettings) {
     vscode.window
       .showInformationMessage(
@@ -49,23 +49,6 @@ function promptInfoMessage(oldVersion: string | undefined) {
         config.migrate(value === 'Keep')
       })
   }
-
-  if (oldVersion === '0.9.6') {
-    vscode.window
-      .showInformationMessage(
-        'Highlight Matching Tag is supported by VSCode Power User course. \n Become a VSCode expert!',
-        'Check it Out!',
-        'Dismiss'
-      )
-      .then((value: string) => {
-        if (value === 'Check it Out!') {
-          vscode.commands.executeCommand(
-            'vscode.open',
-            vscode.Uri.parse('https://a.paddle.com/v2/click/16413/111559?link=1227')
-          )
-        }
-      })
-  }
 }
 
 export function activate(context: vscode.ExtensionContext) {
@@ -75,12 +58,7 @@ export function activate(context: vscode.ExtensionContext) {
   const newVersion: string | undefined = extension && extension.packageJSON.version
 
   // Settings may be updated asynchronously, so version update may need to be moved to after settings are checked
-  config.configure({
-    context,
-    onEditorChange() {
-      promptInfoMessage(oldVersion)
-    },
-  })
+  config.configure({ context, onEditorChange: promptSettingsMigration })
 
   // Can get previous version, by reading it from hmtVersion global state, as it will be updated only here
   context.globalState.update('hmtVersion', newVersion)


### PR DESCRIPTION
This fixes #106. There was no need for that annoying advertisement toast. Adding this advertisement only annoyed more users than it did make them click on that link. Yes, we know, you may rely on this affiliation in one way or another. Putting it in your README is fine - users will click on the course at their own accord. But subjecting all your regular, everyday users of this extension (myself included) to this kindof unwanted advertising - big no-no. 

**For regular users:** the only work-around is to downgrade to 9.0.6 for now

So I suggest you accept this PR to minimise the damage done to your extension.